### PR TITLE
Feat/status

### DIFF
--- a/module/cardigan.mjs
+++ b/module/cardigan.mjs
@@ -39,7 +39,7 @@ Hooks.once('init', function () {
    * @type {String}
    */
   CONFIG.Combat.initiative = {
-    formula: '1d20 + @abilities.dexterity.value',
+    formula: '1d20 + @dexterity.value',
     decimals: 2,
   };
 

--- a/module/data/actor-character.mjs
+++ b/module/data/actor-character.mjs
@@ -31,19 +31,32 @@ export default class CardiganSystemCharacter extends CardiganSystemActorBase {
       }, {})
     );
 
+    // Adiciona campos de Fome e Sede (arrays de 3 checkboxes)
+    schema.status = new fields.SchemaField({
+      hunger: new fields.ArrayField(new fields.BooleanField(), { initial: [false, false, false] }),
+      thirst: new fields.ArrayField(new fields.BooleanField(), { initial: [false, false, false] })
+    });
     return schema;
   }
 
   prepareDerivedData() {
     // Calculate level automatically based on sum of all classes
     this._calculateLevel();
-    
+
     // Loop through ability scores to handle labels.
     for (const key in this.abilities) {
       // Handle ability label localization.
       this.abilities[key].label =
         game.i18n.localize(CONFIG.CARDIGAN.abilities[key]) ?? key;
     }
+
+    // Regra: cada ponto de Stamina adiciona +5 à vida máxima e +5 à energia máxima
+    const stamina = this.abilities?.stamina?.value ?? 0;
+    // Regra: cada level até 10 adiciona +5 à vida e energia máxima
+    const level = this.attributes?.level?.value ?? 0;
+    const levelBonus = Math.min(level, 10) * 5;
+    this.health.max = 0 + (stamina * 5) + levelBonus; // 0 pode ser substituído por um valor base, se desejar
+    this.power.max = 0 + (stamina * 5) + levelBonus;
   }
 
   /**

--- a/module/data/actor-character.mjs
+++ b/module/data/actor-character.mjs
@@ -33,8 +33,8 @@ export default class CardiganSystemCharacter extends CardiganSystemActorBase {
 
     // Adiciona campos de Fome e Sede (arrays de 3 checkboxes)
     schema.status = new fields.SchemaField({
-      hunger: new fields.ArrayField(new fields.BooleanField(), { initial: [false, false, false] }),
-      thirst: new fields.ArrayField(new fields.BooleanField(), { initial: [false, false, false] })
+      hunger: new fields.ArrayField(new fields.BooleanField(), { initial: [false, false, false] }), // Todas desmarcadas
+      thirst: new fields.ArrayField(new fields.BooleanField(), { initial: [false, false, false] })  // Todas desmarcadas
     });
     return schema;
   }
@@ -57,6 +57,32 @@ export default class CardiganSystemCharacter extends CardiganSystemActorBase {
     const levelBonus = Math.min(level, 10) * 5;
     this.health.max = 0 + (stamina * 5) + levelBonus; // 0 pode ser substituído por um valor base, se desejar
     this.power.max = 0 + (stamina * 5) + levelBonus;
+
+    // Verificar estado de Hunger
+    const hunger = this.status?.hunger ?? [];
+    const hungerLevel = hunger.filter(Boolean).length; // Conta os checkboxes marcados
+    if (hungerLevel === 0) {
+      this.status.hungerMessage = ""; // Nenhuma checkbox marcada = sem mensagem
+    } else if (hungerLevel === 2) {
+      this.status.hungerMessage = "O personagem está com muita fome!";
+    } else if (hungerLevel === 1) {
+      this.status.hungerMessage = "O personagem está com fome.";
+    } else if (hungerLevel === 0) {
+      this.status.hungerMessage = "O personagem está começando a sentir fome.";
+    }
+
+    // Verificar estado de Thirst
+    const thirst = this.status?.thirst ?? [];
+    const thirstLevel = thirst.filter(Boolean).length; // Conta os checkboxes marcados
+    if (thirstLevel === 0) {
+      this.status.thirstMessage = ""; // Nenhuma checkbox marcada = sem mensagem
+    } else if (thirstLevel === 2) {
+      this.status.thirstMessage = "O personagem está com muita sede!";
+    } else if (thirstLevel === 1) {
+      this.status.thirstMessage = "O personagem está com sede.";
+    } else if (thirstLevel === 0) {
+      this.status.thirstMessage = "O personagem está começando a sentir sede.";
+    }
   }
 
   /**

--- a/module/data/actor-character.mjs
+++ b/module/data/actor-character.mjs
@@ -33,8 +33,8 @@ export default class CardiganSystemCharacter extends CardiganSystemActorBase {
 
     // Adiciona campos de Fome e Sede (arrays de 3 checkboxes)
     schema.status = new fields.SchemaField({
-      hunger: new fields.ArrayField(new fields.BooleanField(), { initial: [false, false, false] }), // Todas desmarcadas
-      thirst: new fields.ArrayField(new fields.BooleanField(), { initial: [false, false, false] })  // Todas desmarcadas
+      hunger: new fields.ArrayField(new fields.BooleanField(), { initial: [true, true, true] }), // Todas marcadas
+      thirst: new fields.ArrayField(new fields.BooleanField(), { initial: [true, true, true] })  // Todas marcadas
     });
     return schema;
   }
@@ -61,27 +61,27 @@ export default class CardiganSystemCharacter extends CardiganSystemActorBase {
     // Verificar estado de Hunger
     const hunger = this.status?.hunger ?? [];
     const hungerLevel = hunger.filter(Boolean).length; // Conta os checkboxes marcados
-    if (hungerLevel === 0) {
-      this.status.hungerMessage = ""; // Nenhuma checkbox marcada = sem mensagem
+    if (hungerLevel === 3) {
+      this.status.hungerMessage = ""; // Todas marcadas = sem mensagem (estado normal)
     } else if (hungerLevel === 2) {
-      this.status.hungerMessage = "O personagem está com muita fome!";
+      this.status.hungerMessage = "O personagem está ficando com fome. - 2 de Fome";
     } else if (hungerLevel === 1) {
-      this.status.hungerMessage = "O personagem está com fome.";
+      this.status.hungerMessage = "O personagem está ficando com mais fome. - 1 de Fome";
     } else if (hungerLevel === 0) {
-      this.status.hungerMessage = "O personagem está começando a sentir fome.";
+      this.status.hungerMessage = "O personagem está com fome! - 0 de Fome";
     }
 
     // Verificar estado de Thirst
     const thirst = this.status?.thirst ?? [];
     const thirstLevel = thirst.filter(Boolean).length; // Conta os checkboxes marcados
-    if (thirstLevel === 0) {
-      this.status.thirstMessage = ""; // Nenhuma checkbox marcada = sem mensagem
+    if (thirstLevel === 3) {
+      this.status.thirstMessage = ""; // Todas marcadas = sem mensagem (estado normal)
     } else if (thirstLevel === 2) {
-      this.status.thirstMessage = "O personagem está com muita sede!";
+      this.status.thirstMessage = "O personagem está ficando com sede. - 2 de Sede";
     } else if (thirstLevel === 1) {
-      this.status.thirstMessage = "O personagem está com sede.";
+      this.status.thirstMessage = "O personagem está ficando com mais sede. - 1 de Sede";
     } else if (thirstLevel === 0) {
-      this.status.thirstMessage = "O personagem está começando a sentir sede.";
+      this.status.thirstMessage = "O personagem está com sede! - 0 de Sede";
     }
   }
 

--- a/module/data/actor-character.mjs
+++ b/module/data/actor-character.mjs
@@ -34,7 +34,8 @@ export default class CardiganSystemCharacter extends CardiganSystemActorBase {
     // Adiciona campos de Fome e Sede (arrays de 3 checkboxes)
     schema.status = new fields.SchemaField({
       hunger: new fields.ArrayField(new fields.BooleanField(), { initial: [true, true, true] }), // Todas marcadas
-      thirst: new fields.ArrayField(new fields.BooleanField(), { initial: [true, true, true] })  // Todas marcadas
+      thirst: new fields.ArrayField(new fields.BooleanField(), { initial: [true, true, true] }), // Todas marcadas
+      exhaustion: new fields.NumberField({ initial: 0, min: 0, integer: true }) // Pontos de exaustão
     });
     return schema;
   }
@@ -83,6 +84,12 @@ export default class CardiganSystemCharacter extends CardiganSystemActorBase {
     } else if (thirstLevel === 0) {
       this.status.thirstMessage = "O personagem está com sede! - 0 de Sede";
     }
+
+    // Aplicar penalidade de exaustão nos testes de perícias
+    const exhaustion = this.status?.exhaustion ?? 0;
+    // A penalidade será aplicada automaticamente nos rolls através do getRollData()
+    // Cada ponto de exaustão = -1 em todos os testes de perícias
+    this.status.exhaustionPenalty = -exhaustion;
   }
 
   /**
@@ -108,11 +115,24 @@ export default class CardiganSystemCharacter extends CardiganSystemActorBase {
     if (this.abilities) {
       for (let [k, v] of Object.entries(this.abilities)) {
         data[k] = foundry.utils.deepClone(v);
+        
+        // Aplicar penalidade de exaustão em TODAS as perícias
+        const exhaustion = this.status?.exhaustion ?? 0;
+        if (exhaustion > 0) {
+          // Cada ponto de exaustão = -1 no teste de perícia
+          data[k].value = (data[k].value || 0) - exhaustion;
+          console.log(`[CARDIGAN] Aplicando penalidade de exaustão: ${k} = ${v.value} - ${exhaustion} = ${data[k].value}`);
+        }
       }
     }
 
     data.lvl = this.attributes.level.value;
+    
+    // Adicionar informações de exaustão para uso em macros/rolls
+    data.exhaustion = this.status?.exhaustion ?? 0;
+    data.exhaustionPenalty = -(this.status?.exhaustion ?? 0);
 
+    console.log(`[CARDIGAN] RollData final:`, data);
     return data;
   }
 }

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -222,6 +222,9 @@ export class CardiganSystemActorSheet extends api.HandlebarsApplicationMixin(
     this.#dragDrop.forEach((d) => d.bind(this.element));
     this.#disableOverrides();
     
+    // Adicionar event listeners para checkboxes de hunger e thirst
+    this.#addStatusListeners();
+    
     // You may want to add other special handling here
     // Foundry comes with a large number of utility classes, e.g. SearchFilter
     // That you may want to implement yourself.
@@ -688,6 +691,69 @@ export class CardiganSystemActorSheet extends api.HandlebarsApplicationMixin(
     const overrides = foundry.utils.flattenObject(this.actor.overrides);
     for (let k of Object.keys(overrides)) delete submitData[k];
     await this.document.update(submitData);
+  }
+
+  /**
+   * Adiciona event listeners para os checkboxes de hunger e thirst
+   */
+  #addStatusListeners() {
+    const html = this.element;
+    
+    // Escutar mudanças nos checkboxes de Hunger
+    html.querySelectorAll('input[name^="system.status.hunger"]').forEach(input => {
+      input.addEventListener('change', (ev) => {
+        // Só executa se a checkbox foi MARCADA (não desmarcada)
+        if (!ev.target.checked) return;
+        
+        const actor = this.actor;
+        const hunger = actor.system.status.hunger;
+        const hungerLevel = hunger.filter(Boolean).length; // Conta checkboxes marcadas
+
+        let message = "";
+        if (hungerLevel === 2) {
+          message = `${actor.name} está com muita fome!`;
+        } else if (hungerLevel === 1) {
+          message = `${actor.name} está com fome.`;
+        } else if (hungerLevel === 0) {
+          message = `${actor.name} está começando a sentir fome.`;
+        }
+
+        if (message) {
+          ChatMessage.create({ 
+            content: message,
+            speaker: ChatMessage.getSpeaker({ actor: actor })
+          });
+        }
+      });
+    });
+
+    // Escutar mudanças nos checkboxes de Thirst
+    html.querySelectorAll('input[name^="system.status.thirst"]').forEach(input => {
+      input.addEventListener('change', (ev) => {
+        // Só executa se a checkbox foi MARCADA (não desmarcada)
+        if (!ev.target.checked) return;
+        
+        const actor = this.actor;
+        const thirst = actor.system.status.thirst;
+        const thirstLevel = thirst.filter(Boolean).length; // Conta checkboxes marcadas
+
+        let message = "";
+        if (thirstLevel === 2) {
+          message = `${actor.name} está com muita sede!`;
+        } else if (thirstLevel === 1) {
+          message = `${actor.name} está com sede.`;
+        } else if (thirstLevel === 0) {
+          message = `${actor.name} está começando a sentir sede.`;
+        }
+
+        if (message) {
+          ChatMessage.create({ 
+            content: message,
+            speaker: ChatMessage.getSpeaker({ actor: actor })
+          });
+        }
+      });
+    });
   }
 
   /**

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -702,20 +702,26 @@ export class CardiganSystemActorSheet extends api.HandlebarsApplicationMixin(
     // Escutar mudanças nos checkboxes de Hunger
     html.querySelectorAll('input[name^="system.status.hunger"]').forEach(input => {
       input.addEventListener('change', (ev) => {
-        // Só executa se a checkbox foi MARCADA (não desmarcada)
-        if (!ev.target.checked) return;
+        // Só executa se a checkbox foi DESMARCADA (não marcada)
+        if (ev.target.checked) return;
         
         const actor = this.actor;
-        const hunger = actor.system.status.hunger;
-        const hungerLevel = hunger.filter(Boolean).length; // Conta checkboxes marcadas
+        const hunger = [...actor.system.status.hunger]; // Copia o array atual
+        
+        // Determina qual índice da checkbox foi desmarcada
+        const inputName = ev.target.name;
+        const index = parseInt(inputName.split('.').pop()); // Pega o último elemento após o ponto
+        hunger[index] = false; // Desmarca a checkbox que acabou de ser clicada
+        
+        const hungerLevel = hunger.filter(Boolean).length; // Conta com o novo valor
 
         let message = "";
         if (hungerLevel === 2) {
-          message = `${actor.name} está com muita fome!`;
+          message = `${actor.name} está ficando com fome. - 2 de Fome`;
         } else if (hungerLevel === 1) {
-          message = `${actor.name} está com fome.`;
+          message = `${actor.name} está ficando com mais fome. - 1 de Fome`;
         } else if (hungerLevel === 0) {
-          message = `${actor.name} está começando a sentir fome.`;
+          message = `${actor.name} está com fome! - 0 de Fome`;
         }
 
         if (message) {
@@ -730,20 +736,26 @@ export class CardiganSystemActorSheet extends api.HandlebarsApplicationMixin(
     // Escutar mudanças nos checkboxes de Thirst
     html.querySelectorAll('input[name^="system.status.thirst"]').forEach(input => {
       input.addEventListener('change', (ev) => {
-        // Só executa se a checkbox foi MARCADA (não desmarcada)
-        if (!ev.target.checked) return;
+        // Só executa se a checkbox foi DESMARCADA (não marcada)
+        if (ev.target.checked) return;
         
         const actor = this.actor;
-        const thirst = actor.system.status.thirst;
-        const thirstLevel = thirst.filter(Boolean).length; // Conta checkboxes marcadas
+        const thirst = [...actor.system.status.thirst]; // Copia o array atual
+        
+        // Determina qual índice da checkbox foi desmarcada
+        const inputName = ev.target.name;
+        const index = parseInt(inputName.split('.').pop()); // Pega o último elemento após o ponto
+        thirst[index] = false; // Desmarca a checkbox que acabou de ser clicada
+        
+        const thirstLevel = thirst.filter(Boolean).length; // Conta com o novo valor
 
         let message = "";
         if (thirstLevel === 2) {
-          message = `${actor.name} está com muita sede!`;
+          message = `${actor.name} está ficando com sede. - 2 de Sede`;
         } else if (thirstLevel === 1) {
-          message = `${actor.name} está com sede.`;
+          message = `${actor.name} está ficando com mais sede. - 1 de Sede`;
         } else if (thirstLevel === 0) {
-          message = `${actor.name} está começando a sentir sede.`;
+          message = `${actor.name} está com sede! - 0 de Sede`;
         }
 
         if (message) {

--- a/template.json
+++ b/template.json
@@ -57,6 +57,28 @@
         "psionics": {
           "value": 0
         }
+      },
+      "status": {
+        "hunger": [true, true, true],
+        "thirst": [true, true, true],
+        "exhaustion": 0
+      },
+      "classes": {
+        "andarilho": 0,
+        "guerreiro": 0,
+        "ladino": 0,
+        "feiticeiro": 0
+      },
+      "details": {
+        "name": "",
+        "age": 0,
+        "race": "",
+        "movement": 0,
+        "criticalHit": 0
+      },
+      "experience": {
+        "current": 0,
+        "nextLevel": 100
       }
     },
     "npc": {

--- a/templates/actor/features.hbs
+++ b/templates/actor/features.hbs
@@ -235,6 +235,25 @@
               />
             </div>
           </div>
+          <!-- Fome e Sede -->
+          <div class='fome-sede-container'>
+            <div class='hunger-row horizontal-field'>
+              <label class='status-label label-left'>Hunger:</label>
+              <div class='checkbox-group'>
+                {{#each system.status.hunger as |checked idx|}}
+                  <input type='checkbox' data-action='toggleHunger' data-idx='{{idx}}' {{#if checked}}checked{{/if}} />
+                {{/each}}
+              </div>
+            </div>
+            <div class='thirst-row horizontal-field'>
+              <label class='status-label label-left'>Thirst:</label>
+              <div class='checkbox-group'>
+                {{#each system.status.thirst as |checked idx|}}
+                  <input type='checkbox' data-action='toggleThirst' data-idx='{{idx}}' {{#if checked}}checked{{/if}} />
+                {{/each}}
+              </div>
+            </div>
+          </div>
         </div>
       </div>
 

--- a/templates/actor/features.hbs
+++ b/templates/actor/features.hbs
@@ -263,6 +263,20 @@
                 {{/each}}
               </div>
             </div>
+            <!-- Exaustão -->
+            <div class='exhaustion-row horizontal-field'>
+              <label class='status-label label-left'>Exaustão:</label>
+              <div class='status-display'>
+                <input
+                  type='number'
+                  name='system.status.exhaustion'
+                  value='{{system.status.exhaustion}}'
+                  data-dtype='Number'
+                  min='0'
+                  class='status-current'
+                />
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -276,7 +290,7 @@
               <label
                 class='rollable'
                 data-action='roll'
-                data-roll='1d20+{{ability.value}}'
+                data-roll='1d20+@{{key}}.value'
                 data-label='{{localize (lookup @root.config.abilities key)}}'
                 data-key='{{key}}'
               >{{localize (lookup @root.config.abilities key)}}</label>

--- a/templates/actor/features.hbs
+++ b/templates/actor/features.hbs
@@ -241,7 +241,12 @@
               <label class='status-label label-left'>Hunger:</label>
               <div class='checkbox-group'>
                 {{#each system.status.hunger as |checked idx|}}
-                  <input type='checkbox' data-action='toggleHunger' data-idx='{{idx}}' {{#if checked}}checked{{/if}} />
+                  <input 
+                    type='checkbox' 
+                    name='system.status.hunger.{{idx}}' 
+                    {{#if checked}}checked{{/if}} 
+                    data-dtype='Boolean'
+                  />
                 {{/each}}
               </div>
             </div>
@@ -249,7 +254,12 @@
               <label class='status-label label-left'>Thirst:</label>
               <div class='checkbox-group'>
                 {{#each system.status.thirst as |checked idx|}}
-                  <input type='checkbox' data-action='toggleThirst' data-idx='{{idx}}' {{#if checked}}checked{{/if}} />
+                  <input 
+                    type='checkbox' 
+                    name='system.status.thirst.{{idx}}' 
+                    {{#if checked}}checked{{/if}} 
+                    data-dtype='Boolean'
+                  />
                 {{/each}}
               </div>
             </div>


### PR DESCRIPTION
### Description
Implementação da funcionalidade de Exaustão no sistema Cardigan. Agora, cada ponto de exaustão reduz o resultado de todos os testes de perícias em -1 por ponto. Além disso, ajustes foram feitos para garantir que os rolls considerem corretamente a penalidade de exaustão.

### Changes Proposed
- **feat**:  
   - Adicionado o campo de exaustão no [template.json] e no esquema do ator (actor-character.mjs).
   - Penalidade de exaustão aplicada automaticamente nos rolls através do getRollData.
- **fix** :
   - Corrigido o uso de valores diretos no template features.hbs para usar os dados processados pelo getRollData.
   - Ajustada a fórmula de iniciativa para considerar a penalidade de exaustão.
- **docs**: 
  - Adicionado tooltip explicativo para o campo de exaustão na ficha.
- **styles**: 
  - Campo de exaustão estilizado para seguir o padrão visual dos outros campos de status.
- **refactor**: 

- **test**: 

- **chore**: 


### Details
- Campo de Exaustão: Adicionado no [template.json] e no esquema do ator. O valor inicial é 0 e pode ser ajustado manualmente na ficha.
- Penalidade Automática: Cada ponto de exaustão reduz o resultado de todos os testes de perícias em -1 por ponto. Isso é aplicado automaticamente no getRollData.
- Correção de Templates: O template features.hbs foi ajustado para usar @key.value nos rolls, garantindo que a penalidade de exaustão seja aplicada.
- Fórmula de Iniciativa: Atualizada para usar os dados processados pelo getRollData.

### Screenshots
Prints importantes

### Notes
Observações